### PR TITLE
Update in save

### DIFF
--- a/kalibro_client/base.py
+++ b/kalibro_client/base.py
@@ -33,8 +33,16 @@ class Base(object):
                                     headers={'Content-Type': 'application/json'})
         return response.json()
 
+    def _update_request(self):
+        return self.request(str(self.id),
+                        {self.entity_name(): self._asdict(), 'id': str(self.id)},
+                        method='put')
+
     def save(self):
-        response = self.request('', {self.entity_name(): self._asdict()})
+        if not self.id:
+            response = self.request('', {self.entity_name(): self._asdict()})
+        else:
+            response = self._update_request()
 
         if 'errors' not in response:
             response_body = response[self.entity_name()]
@@ -57,9 +65,7 @@ class Base(object):
             if self._is_valid_field(attr):
                 setattr(self, attr, value)
 
-        response = self.request(str(self.id),
-            {self.entity_name(): self._asdict(), 'id': str(self.id)},
-            method='put')
+        response = self._update_request()
 
         if 'errors' in response:
             raise KalibroClientSaveError(response['errors'])

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,16 +5,27 @@ from mock import Mock, patch, create_autospec
 from nose.tools import assert_equal, assert_true, assert_raises_regexp, raises
 import dateutil.parser
 
-from kalibro_client.base import Base, attributes_class_constructor, entity_name_decorator
+from kalibro_client.base import Base, attributes_class_constructor, \
+    entity_name_decorator
 from kalibro_client.errors import KalibroClientSaveError
 
 from .helpers import not_raises
 
-class Derived(attributes_class_constructor('DerivedAttr', ('name', 'description'), identity=False), Base):
+
+class Derived(attributes_class_constructor('DerivedAttr',
+                                           ('name', 'description'),
+                                           identity=False), Base):
     pass
+
 
 @entity_name_decorator
 class CompositeEntity(Base):
+    pass
+
+
+@entity_name_decorator
+class IdentifiedBase(attributes_class_constructor('Identified',
+                                                  ('attribute')), Base):
     pass
 
 
@@ -119,13 +130,9 @@ class TestBase(TestCase):
         assert_equal(CompositeEntity().endpoint(),
                      "composite_entities")
 
-    @entity_name_decorator
-    class IdentifiedBase(attributes_class_constructor('Identified', ('attribute')), Base):
-        pass
-
     @not_raises(KalibroClientSaveError)
     def test_successful_save(self):
-        subject = self.IdentifiedBase(attribute='test')
+        subject = IdentifiedBase(attribute='test')
 
         id = 42
         date = dateutil.parser.parse("2015-07-05T22:16:18+00:00")
@@ -142,36 +149,19 @@ class TestBase(TestCase):
         assert_equal(subject.created_at, date)
         assert_equal(subject.updated_at, date)
 
-    @not_raises(KalibroClientSaveError)
-    def test_successful_save_with_update(self):
-        date = dateutil.parser.parse("2015-07-05T22:16:18+00:00")
-        updated_date = dateutil.parser.parse("2020-07-05T22:16:18+00:00")
-        new_attribute_value = 'new_value'
+    def test_unsuccessful_update_without_id(self):
+        subject = IdentifiedBase(id=None, attribute='test')
+        subject.request = create_autospec(subject.request,
+            side_effect=AssertionError("Request should not be called for update without id"))
 
-        subject = self.IdentifiedBase(id=42, created_at=date, updated_at=date, attribute='test')
+        with assert_raises_regexp(KalibroClientSaveError,
+                                  "Cannot update a record that is not saved."):
+            subject.update(attribute='new value')
 
-        request_params = {subject.entity_name(): subject._asdict()}
-        request_params['id'] = str(subject.id)
-        request_params[subject.entity_name()]['attribute'] = new_attribute_value
-
-        successful_response = {'identified_base': {'id': str(subject.id),
-                                                   'created_at': date.isoformat(),
-                                                   'updated_at': updated_date.isoformat(),
-                                                   'attribute': new_attribute_value}}
-        subject.request = create_autospec(subject.request, return_value=successful_response)
-        subject.attribute = new_attribute_value
-        subject.save()
-
-        subject.request.assert_called_with(str(subject.id), request_params, method='put')
-
-        assert_equal(subject.id, 42)
-        assert_equal(subject.created_at, date)
-        assert_equal(subject.updated_at, updated_date)
-        assert_equal(subject.attribute, new_attribute_value)
 
     @raises(KalibroClientSaveError)
     def test_unsuccessful_save(self):
-        subject = self.IdentifiedBase(attribute='test')
+        subject = IdentifiedBase(attribute='test')
 
         unsuccessful_response = {'errors': ['A string with an error']}
         subject.request = create_autospec(subject.request, return_value=unsuccessful_response)
@@ -180,45 +170,10 @@ class TestBase(TestCase):
 
         subject.request.assert_called_with('', {subject.entity_name() : subject._asdict()})
 
-    @not_raises(KalibroClientSaveError)
-    def test_successful_update(self):
-        date = dateutil.parser.parse("2015-07-05T22:16:18+00:00")
-        updated_date = dateutil.parser.parse("2020-07-05T22:16:18+00:00")
-        new_attribute_value = 'new_value'
-
-        subject = self.IdentifiedBase(id=42, created_at=date, updated_at=date, attribute='test')
-
-        request_params = {subject.entity_name(): subject._asdict()}
-        request_params['id'] = str(subject.id)
-        request_params[subject.entity_name()]['attribute'] = new_attribute_value
-
-        successful_response = {'identified_base': {'id': str(subject.id),
-                                                   'created_at': date.isoformat(),
-                                                   'updated_at': updated_date.isoformat(),
-                                                   'attribute': new_attribute_value}}
-        subject.request = create_autospec(subject.request, return_value=successful_response)
-
-        subject.update(attribute=new_attribute_value)
-
-        subject.request.assert_called_with(str(subject.id), request_params, method='put')
-
-        assert_equal(subject.id, 42)
-        assert_equal(subject.created_at, date)
-        assert_equal(subject.updated_at, updated_date)
-        assert_equal(subject.attribute, new_attribute_value)
-
-    def test_unsuccessful_update_without_id(self):
-        subject = self.IdentifiedBase(id=None, attribute='test')
-        subject.request = create_autospec(subject.request,
-            side_effect=AssertionError("Request should not be called for update without id"))
-
-        with assert_raises_regexp(KalibroClientSaveError,
-                                  "Cannot update a record that is not saved."):
-            subject.update(attribute='new value')
 
     @raises(KalibroClientSaveError)
     def test_unsuccessful_update(self):
-        subject = self.IdentifiedBase(id=42, attribute='test')
+        subject = IdentifiedBase(id=42, attribute='test')
         unsuccessful_response = {'errors': ['A string with an error']}
 
         subject.request = create_autospec(subject.request, return_value=unsuccessful_response)
@@ -226,9 +181,9 @@ class TestBase(TestCase):
         subject.update(attribute='new_value')
 
     def test_is_valid_field(self):
-        assert_true(self.IdentifiedBase._is_valid_field('attribute'))
-        assert_true(not self.IdentifiedBase._is_valid_field('invalid'))
-        assert_true(not self.IdentifiedBase._is_valid_field('errors'))
+        assert_true(IdentifiedBase._is_valid_field('attribute'))
+        assert_true(not IdentifiedBase._is_valid_field('invalid'))
+        assert_true(not IdentifiedBase._is_valid_field('errors'))
 
 
 class TestsEntityNameDecorator(TestCase):
@@ -312,3 +267,55 @@ class TestAttributesClassConstructor(TestCase):
     @raises(ValueError)
     def test_updated_at_setter_invalid(self):
         self.identified.updated_at = "wrong"
+
+
+class TestSuccessfulUpdates(TestCase):
+
+    def setUp(self):
+        self.date = dateutil.parser.parse("2015-07-05T22:16:18+00:00")
+        self.updated_date = dateutil.parser.parse("2020-07-05T22:16:18+00:00")
+        self.new_attribute_value = 'new_value'
+
+        self.subject = IdentifiedBase(id=42, created_at=self.date,
+                                      updated_at=self.date, attribute='test')
+
+        self.request_params = {self.subject.entity_name(): self.subject._asdict()}
+        self.request_params['id'] = str(self.subject.id)
+        self.request_params[self.subject.entity_name()]['attribute'] = self.new_attribute_value
+
+        self.successful_response = {'identified_base': {'id': str(self.subject.id),
+                                                        'created_at': self.date.isoformat(),
+                                                        'updated_at': self.updated_date.isoformat(),
+                                                        'attribute': self.new_attribute_value}}
+
+    @not_raises(KalibroClientSaveError)
+    def test_successful_save_with_update(self):
+        self.subject.request = create_autospec(self.subject.request,
+                                               return_value=self.successful_response)
+        self.subject.attribute = self.new_attribute_value
+        self.subject.save()
+
+        self.subject.request.assert_called_with(str(self.subject.id),
+                                                self.request_params,
+                                                method='put')
+
+        assert_equal(self.subject.id, 42)
+        assert_equal(self.subject.created_at,self.date)
+        assert_equal(self.subject.updated_at, self.updated_date)
+        assert_equal(self.subject.attribute, self.new_attribute_value)
+
+    @not_raises(KalibroClientSaveError)
+    def test_successful_update(self):
+        self.subject.request = create_autospec(self.subject.request,
+                                               return_value=self.successful_response)
+
+        self.subject.update(attribute=self.new_attribute_value)
+
+        self.subject.request.assert_called_with(str(self.subject.id),
+                                                self.request_params,
+                                                method='put')
+
+        assert_equal(self.subject.id, 42)
+        assert_equal(self.subject.created_at, self.date)
+        assert_equal(self.subject.updated_at, self.updated_date)
+        assert_equal(self.subject.attribute, self.new_attribute_value)


### PR DESCRIPTION
When trying to save an object that already has an Id, the request will be made as PUT instead of a POST