### PR TITLE
Refactor the Base mixin splitting it into two classes.

### DIFF
--- a/kalibro_client/configurations/base.py
+++ b/kalibro_client/configurations/base.py
@@ -1,7 +1,7 @@
 import kalibro_client
-from kalibro_client.base import Base as ClientBase
+from kalibro_client.base import BaseCRUD
 
-class Base(ClientBase):
+class Base(BaseCRUD):
     @classmethod
     def service_address(cls):
         return kalibro_client.config()['configurations_address']

--- a/kalibro_client/processor/base.py
+++ b/kalibro_client/processor/base.py
@@ -1,7 +1,7 @@
 import kalibro_client
-from kalibro_client.base import Base as ClientBase
+from kalibro_client.base import BaseCRUD
 
-class Base(ClientBase):
+class Base(BaseCRUD):
     @classmethod
     def service_address(cls):
         return kalibro_client.config()['processor_address']

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,7 +5,7 @@ from mock import Mock, patch, create_autospec
 from nose.tools import assert_equal, assert_true, assert_raises_regexp, raises
 import dateutil.parser
 
-from kalibro_client.base import Base, attributes_class_constructor, \
+from kalibro_client.base import BaseCRUD, attributes_class_constructor, \
     entity_name_decorator
 from kalibro_client.errors import KalibroClientSaveError, KalibroClientDeleteError, \
     KalibroClientNotFoundError
@@ -15,22 +15,22 @@ from .helpers import not_raises
 
 class Derived(attributes_class_constructor('DerivedAttr',
                                            ('name', 'description'),
-                                           identity=False), Base):
+                                           identity=False), BaseCRUD):
     pass
 
 
 @entity_name_decorator
-class DerivedWithEntityName(attributes_class_constructor('DerivedAttr', ('name', 'description'), identity=False), Base):
+class DerivedWithEntityName(attributes_class_constructor('DerivedAttr', ('name', 'description'), identity=False), BaseCRUD):
     pass
 
 @entity_name_decorator
-class CompositeEntity(Base):
+class CompositeEntity(BaseCRUD):
     pass
 
 
 @entity_name_decorator
 class IdentifiedBase(attributes_class_constructor('Identified',
-                                                  ('attribute')), Base):
+                                                  ('attribute')), BaseCRUD):
     pass
 
 
@@ -53,7 +53,7 @@ class TestBase(TestCase):
 
     @raises(NotImplementedError)
     def test_service_address(self):
-        Base.service_address()
+        BaseCRUD.service_address()
 
     @patch('requests.request')
     def test_request(self, requests_request):
@@ -303,7 +303,7 @@ class TestBase(TestCase):
 
 class TestsEntityNameDecorator(TestCase):
     @entity_name_decorator
-    class Entity(Base):
+    class Entity(BaseCRUD):
         def __init__(self):
             pass
 


### PR DESCRIPTION
* Base with the extended object methods like conversion from dictionary to object
* BaseCRUD with the request methods

This sepparation will be useful when implementing the miscellaneous classes
which will not mixin BaseCRUD but just Base.