### PR TITLE
Make fails explicit

### DIFF
--- a/kalibro_client/errors.py
+++ b/kalibro_client/errors.py
@@ -1,6 +1,16 @@
 class KalibroClientError(RuntimeError):
     pass
 
+class KalibroClientRequestError(KalibroClientError):
+    def __init__(self, response, *args, **kwargs):
+        super(KalibroClientRequestError, self).__init__(response.json().get('errors', None),
+            *args, **kwargs)
+        self._response = response
+
+    @property
+    def response(self):
+        return self._response
+
 class KalibroClientSaveError(KalibroClientError):
     pass
 

--- a/kalibro_client/processor/metric_collector_details.py
+++ b/kalibro_client/processor/metric_collector_details.py
@@ -2,7 +2,7 @@ from kalibro_client.base import attributes_class_constructor, \
     entity_name_decorator
 from kalibro_client.processor.base import Base
 from kalibro_client.miscellaneous import NativeMetric
-from kalibro_client.errors import KalibroClientNotFoundError
+from kalibro_client.errors import KalibroClientNotFoundError, KalibroClientRequestError
 
 @entity_name_decorator
 class MetricCollectorDetails(attributes_class_constructor('MetricCollectorDetailsAttr',
@@ -37,11 +37,11 @@ class MetricCollectorDetails(attributes_class_constructor('MetricCollectorDetail
 
     @classmethod
     def find_by_name(cls, name):
-        response = cls.request('find', params={"name": name})
         try:
+            response = cls.request('find', params={"name": name})
             return cls(**response['metric_collector_details'])
-        except KeyError:
-            error = response.get('error', None)
+        except KalibroClientRequestError as error:
+            error = error.response.json().get('error', None)
             raise KalibroClientNotFoundError(error)
 
     @classmethod

--- a/kalibro_client/processor/metric_collector_details.py
+++ b/kalibro_client/processor/metric_collector_details.py
@@ -41,8 +41,8 @@ class MetricCollectorDetails(attributes_class_constructor('MetricCollectorDetail
             response = cls.request('find', params={"name": name})
             return cls(**response['metric_collector_details'])
         except KalibroClientRequestError as error:
-            error = error.response.json().get('error', None)
-            raise KalibroClientNotFoundError(error)
+            error_messages = error.response.json().get('error', None)
+            raise KalibroClientNotFoundError(error_messages)
 
     @classmethod
     def all_names(cls):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 import json
+import requests
 from unittest import TestCase
 
 from mock import Mock, patch, create_autospec

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,7 +1,7 @@
 from unittest import TestCase, skip
 import dateutil
 from nose.tools import assert_equal, assert_true, raises
-from mock import patch
+from mock import patch, Mock
 
 import kalibro_client
 from kalibro_client.processor import Project, Repository, ProcessTime,\
@@ -9,7 +9,7 @@ from kalibro_client.processor import Project, Repository, ProcessTime,\
     TreeMetricResult
 from kalibro_client.configurations import MetricConfiguration
 from kalibro_client.processor.base import Base
-from kalibro_client.errors import KalibroClientNotFoundError
+from kalibro_client.errors import KalibroClientNotFoundError, KalibroClientRequestError
 
 from factories import ProjectFactory, RepositoryFactory, KalibroModuleFactory,\
     ProcessingFactory, MetricCollectorDetailsFactory, NativeMetricFactory,\
@@ -393,9 +393,10 @@ class TestMetricCollectorDetails(TestCase):
 
     @raises(KalibroClientNotFoundError)
     def test_find_by_name_invalid_collector(self):
-        error_response = {'error': "Metric Collector '{}' not found.".format(self.subject.name)}
+        response_body = Mock()
+        response_body.json = Mock(return_value={'error': "Metric Collector '{}' not found.".format(self.subject.name)})
         with patch.object(MetricCollectorDetails, 'request',
-                          return_value=error_response) as metric_collector_details_request:
+                          side_effect=KalibroClientRequestError(response_body)) as metric_collector_details_request:
             MetricCollectorDetails.find_by_name(self.subject.name)
 
     def test_all_names(self):


### PR DESCRIPTION
Now, when we do some request, we look to the response status to check
whether it was successful.

Before this commit, some errors were simply ignored.

Signed off by: Rafael Reggiani Manzo <rr.manzo@gmail.com>