### PR TITLE
Moves BaseCRUD#request to RequestMethods

### DIFF
--- a/kalibro_client/base.py
+++ b/kalibro_client/base.py
@@ -19,6 +19,19 @@ class RequestMethods(object):
     def delete_prefix(self):
         return ""
 
+    @classmethod
+    def entity_name(cls):
+        raise NotImplementedError
+
+    @classmethod
+    def endpoint(cls):
+        return inflection.pluralize(cls.entity_name())
+
+    @classmethod
+    def service_address(cls):
+        raise NotImplementedError
+
+
 class Base(object):
     @classmethod
     def _is_valid_field(cls, name):
@@ -35,18 +48,6 @@ class Base(object):
 
 
 class BaseCRUD(Base, RequestMethods):
-    @classmethod
-    def endpoint(cls):
-        return inflection.pluralize(cls.entity_name())
-
-    @classmethod
-    def entity_name(cls):
-        raise NotImplementedError
-
-    @classmethod
-    def service_address(cls):
-        raise NotImplementedError
-
     @classmethod
     def request(cls, action, params=None, method='post', prefix=None):
         url = cls.service_address()

--- a/kalibro_client/base.py
+++ b/kalibro_client/base.py
@@ -31,6 +31,21 @@ class RequestMethods(object):
     def service_address(cls):
         raise NotImplementedError
 
+    @classmethod
+    def request(cls, action, params=None, method='post', prefix=None):
+        url = cls.service_address()
+
+        if prefix:
+            url += "/" + prefix
+        url += "/{}/{}".format(cls.endpoint(), action)
+
+        if params is not None and 'id' in params:
+            url = url.replace(':id', str(params.pop('id')))
+
+        response = requests.request(method, url, data=json.dumps(params),
+                                    headers={'Content-Type': 'application/json'})
+        return response.json()
+
 
 class Base(object):
     @classmethod
@@ -48,21 +63,6 @@ class Base(object):
 
 
 class BaseCRUD(Base, RequestMethods):
-    @classmethod
-    def request(cls, action, params=None, method='post', prefix=None):
-        url = cls.service_address()
-
-        if prefix:
-            url += "/" + prefix
-        url += "/{}/{}".format(cls.endpoint(), action)
-
-        if params is not None and 'id' in params:
-            url = url.replace(':id', str(params.pop('id')))
-
-        response = requests.request(method, url, data=json.dumps(params),
-                                    headers={'Content-Type': 'application/json'})
-        return response.json()
-
     @classmethod
     def find(cls, id):
         response = cls.request(':id', params={'id': id}, method='get')

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -40,103 +40,10 @@ class TestBase(TestCase):
         self.attributes = {'name': 'A random Project',
                            'description': 'A real example Project'}
         self.base = Derived(**self.attributes)
-        self.headers = {'Content-Type': 'application/json'}
-        self.nulldata = json.dumps(None)  # request method always calls json.dumps
-        self.json_dumps_attributes = json.dumps(self.attributes)
 
     def test_init(self):
-        assert_equal(self.base.name, 'A random Project')
-        assert_equal(self.base.description, 'A real example Project')
-
-    @raises(NotImplementedError)
-    def test_entity_name(self):
-        self.base.entity_name()
-
-    @patch('requests.request')
-    def test_request(self, requests_request):
-        with patch.object(type(self.base), 'endpoint', return_value="base") as mock_endpoint, \
-            patch.object(type(self.base), 'service_address', return_value="http://base:8000") as mock_service_address:
-            response_mock = Mock()
-            response_mock.json = Mock(return_value=self.attributes)
-            requests_request.return_value = response_mock
-
-            assert_equal(self.base.request("find", method='get'), self.attributes)
-            requests_request.assert_called_once_with('get', "http://base:8000/base/find",
-                                                     data=self.nulldata, headers=self.headers)
-            mock_endpoint.assert_called_once()
-            mock_service_address.assert_called_once()
-            response_mock.json.assert_called_with()
-
-    @patch('requests.request')
-    def test_request_with_prefix(self, requests_request):
-        with patch.object(type(self.base), 'endpoint', return_value="base") as mock_endpoint, \
-            patch.object(type(self.base), 'service_address', return_value="http://base:8000") as mock_service_address:
-            response_mock = Mock()
-            response_mock.json = Mock(return_value=self.attributes)
-            requests_request.return_value = response_mock
-
-            assert_equal(self.base.request("find", method='get', prefix='prefix'),
-                         self.attributes)
-            requests_request.assert_called_once_with('get', "http://base:8000/prefix/base/find",
-                                                     data=self.nulldata, headers=self.headers)
-            response_mock.json.assert_called_with()
-            mock_endpoint.assert_called_once()
-            mock_service_address.assert_called_once()
-
-    @patch('requests.request')
-    def test_request_with_default_method(self, requests_request):
-        with patch.object(type(self.base), 'endpoint', return_value="base") as mock_endpoint, \
-            patch.object(type(self.base), 'service_address', return_value="http://base:8000") as mock_service_address:
-
-            response_mock = Mock()
-            response_mock.json = Mock(return_value=self.attributes)
-            requests_request.return_value = response_mock
-
-            assert_equal(self.base.request("create"), self.attributes)
-            requests_request.assert_called_once_with('post', "http://base:8000/base/create",
-                                                     data=self.nulldata, headers=self.headers)
-            response_mock.json.assert_called_with()
-            mock_endpoint.assert_called_once()
-            mock_service_address.assert_called_once()
-
-    @patch('json.dumps')
-    @patch('requests.request')
-    def test_request_with_parameters(self, requests_request, json_dumps):
-        with patch.object(type(self.base), 'endpoint', return_value="base") as mock_endpoint, \
-            patch.object(type(self.base), 'service_address', return_value="http://base:8000") as mock_service_address:
-            response_mock = Mock()
-            response_mock.json = Mock(return_value=self.attributes)
-            requests_request.return_value = response_mock
-            json_dumps.return_value = self.json_dumps_attributes
-
-            assert_equal(self.base.request("create", params=self.attributes), self.attributes)
-            json_dumps.assert_called_once_with(self.attributes)
-            requests_request.assert_called_once_with('post', "http://base:8000/base/create",
-                                                     data=self.json_dumps_attributes, headers=self.headers)
-            response_mock.json.assert_called_with()
-            mock_endpoint.assert_called_once()
-            mock_service_address.assert_called_once()
-
-    @patch('json.dumps')
-    @patch('requests.request')
-    def test_request_with_id_parameter(self, requests_request, json_dumps):
-        with patch.object(type(self.base), 'endpoint', return_value="base") as mock_endpoint, \
-            patch.object(type(self.base), 'service_address', return_value="http://base:8000") as mock_service_address:
-            response_mock = Mock()
-            response_mock.json = Mock(return_value=self.attributes)
-            requests_request.return_value = response_mock
-
-            attributes = {'id': 42}
-            self.base.request(":id/something", params=attributes)
-            json_dumps.assert_called_once_with({})
-            requests_request.assert_called_once_with('post', "http://base:8000/base/42/something",
-                                                     data=json.dumps({}), headers=self.headers)
-            response_mock.json.assert_called_with()
-            mock_endpoint.assert_called_once()
-
-    @raises(NotImplementedError)
-    def test_endpoint_base(self):
-        self.base.endpoint()
+        assert_equal(self.base.name, self.attributes['name'])
+        assert_equal(self.base.description, self.attributes['description'])
 
     @not_raises(KalibroClientSaveError)
     def test_successful_save(self):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -23,6 +23,7 @@ class Derived(attributes_class_constructor('DerivedAttr',
 class DerivedWithEntityName(attributes_class_constructor('DerivedAttr', ('name', 'description'), identity=False), BaseCRUD):
     pass
 
+
 @entity_name_decorator
 class CompositeEntity(BaseCRUD):
     pass
@@ -50,10 +51,6 @@ class TestBase(TestCase):
     @raises(NotImplementedError)
     def test_entity_name(self):
         self.base.entity_name()
-
-    @raises(NotImplementedError)
-    def test_service_address(self):
-        BaseCRUD.service_address()
 
     @patch('requests.request')
     def test_request(self, requests_request):
@@ -140,22 +137,6 @@ class TestBase(TestCase):
     @raises(NotImplementedError)
     def test_endpoint_base(self):
         self.base.endpoint()
-
-    def test_endpoint(self):
-        cases = {
-            'repository': 'repositories',
-            'project': 'projects',
-            'processing': 'processings',
-            'process_time': 'process_times'
-        }
-
-        for (singular, plural) in cases.items():
-            with patch.object(self.base.__class__, 'entity_name',
-                              return_value=singular):
-                assert_equal(self.base.endpoint(), plural)
-
-        assert_equal(CompositeEntity().endpoint(),
-                     "composite_entities")
 
     @not_raises(KalibroClientSaveError)
     def test_successful_save(self):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -64,16 +64,6 @@ class TestBase(TestCase):
         assert_equal(subject.created_at, date)
         assert_equal(subject.updated_at, date)
 
-    def test_unsuccessful_update_without_id(self):
-        subject = IdentifiedBase(id=None, attribute='test')
-        subject.request = create_autospec(subject.request,
-            side_effect=AssertionError("Request should not be called for update without id"))
-
-        with assert_raises_regexp(KalibroClientSaveError,
-                                  "Cannot update a record that is not saved."):
-            subject.update(attribute='new value')
-
-
     @raises(KalibroClientSaveError)
     def test_unsuccessful_save(self):
         subject = IdentifiedBase(attribute='test')
@@ -85,6 +75,14 @@ class TestBase(TestCase):
 
         subject.request.assert_called_with('', {subject.entity_name() : subject._asdict()})
 
+    def test_unsuccessful_update_without_id(self):
+        subject = IdentifiedBase(id=None, attribute='test')
+        subject.request = create_autospec(subject.request,
+            side_effect=AssertionError("Request should not be called for update without id"))
+
+        with assert_raises_regexp(KalibroClientSaveError,
+                                  "Cannot update a record that is not saved."):
+            subject.update(attribute='new value')
 
     @raises(KalibroClientSaveError)
     def test_unsuccessful_update(self):

--- a/tests/test_request_methods.py
+++ b/tests/test_request_methods.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+from nose.tools import assert_equal, assert_true, raises
+from mock import patch
+
+from kalibro_client.base import RequestMethods
+
+
+class TestRequestMethods(TestCase):
+
+    def setUp(self):
+        self.subject = RequestMethods()
+
+    def test_prefixes(self):
+        assert_equal(self.subject.save_prefix(), "")
+        assert_equal(self.subject.update_prefix(), "")
+        assert_equal(self.subject.delete_prefix(), "")
+
+    def test_endpoint(self):
+        cases = {
+            'repository': 'repositories',
+            'project': 'projects',
+            'processing': 'processings',
+            'process_time': 'process_times'
+        }
+
+        for (singular, plural) in cases.items():
+            with patch.object(self.subject.__class__, 'entity_name',
+                              return_value=singular):
+                assert_equal(self.subject.endpoint(), plural)
+
+    @raises(NotImplementedError)
+    def test_service_address(self):
+        self.subject.service_address()

--- a/tests/test_request_methods.py
+++ b/tests/test_request_methods.py
@@ -1,6 +1,7 @@
+import json
 from unittest import TestCase
 from nose.tools import assert_equal, assert_true, raises
-from mock import patch
+from mock import Mock, patch
 
 from kalibro_client.base import RequestMethods
 
@@ -8,7 +9,12 @@ from kalibro_client.base import RequestMethods
 class TestRequestMethods(TestCase):
 
     def setUp(self):
+        self.attributes = {'name': 'A random Project',
+                           'description': 'A real example Project'}
         self.subject = RequestMethods()
+        self.nulldata = json.dumps(None)  # request method always calls json.dumps
+        self.headers = {'Content-Type': 'application/json'}
+        self.json_dumps_attributes = json.dumps(self.attributes)
 
     def test_prefixes(self):
         assert_equal(self.subject.save_prefix(), "")
@@ -31,3 +37,93 @@ class TestRequestMethods(TestCase):
     @raises(NotImplementedError)
     def test_service_address(self):
         self.subject.service_address()
+
+    @raises(NotImplementedError)
+    def test_entity_name(self):
+        self.subject.entity_name()
+
+    @patch('requests.request')
+    def test_request(self, requests_request):
+        with patch.object(type(self.subject), 'endpoint', return_value="request_methods") as mock_endpoint, \
+            patch.object(type(self.subject), 'service_address',
+                         return_value="http://request_methods:8000") as mock_service_address:
+            response_mock = Mock()
+            response_mock.json = Mock(return_value=self.attributes)
+            requests_request.return_value = response_mock
+
+            assert_equal(self.subject.request("find", method='get'), self.attributes)
+            requests_request.assert_called_once_with('get', "http://request_methods:8000/request_methods/find",
+                                                     data=self.nulldata, headers=self.headers)
+            mock_endpoint.assert_called_once()
+            mock_service_address.assert_called_once()
+            response_mock.json.assert_called_with()
+
+    @patch('requests.request')
+    def test_request_with_prefix(self, requests_request):
+        with patch.object(type(self.subject), 'endpoint', return_value="request_methods") as mock_endpoint, \
+             patch.object(type(self.subject), 'service_address', return_value="http://request_methods:8000") as mock_service_address:
+
+            response_mock = Mock()
+            response_mock.json = Mock(return_value=self.attributes)
+            requests_request.return_value = response_mock
+
+            assert_equal(self.subject.request("find", method='get', prefix='prefix'),
+                         self.attributes)
+            requests_request.assert_called_once_with('get', "http://request_methods:8000/prefix/request_methods/find",
+                                                     data=self.nulldata, headers=self.headers)
+            response_mock.json.assert_called_with()
+            mock_endpoint.assert_called_once()
+            mock_service_address.assert_called_once()
+
+    @patch('requests.request')
+    def test_request_with_default_method(self, requests_request):
+        with patch.object(type(self.subject), 'endpoint', return_value="request_methods") as mock_endpoint, \
+             patch.object(type(self.subject), 'service_address', return_value="http://request_methods:8000") as mock_service_address:
+
+            response_mock = Mock()
+            response_mock.json = Mock(return_value=self.attributes)
+            requests_request.return_value = response_mock
+
+            assert_equal(self.subject.request("create"), self.attributes)
+            requests_request.assert_called_once_with('post', "http://request_methods:8000/request_methods/create",
+                                                     data=self.nulldata, headers=self.headers)
+            response_mock.json.assert_called_with()
+            mock_endpoint.assert_called_once()
+            mock_service_address.assert_called_once()
+
+    @patch('json.dumps')
+    @patch('requests.request')
+    def test_request_with_parameters(self, requests_request, json_dumps):
+        with patch.object(type(self.subject), 'endpoint', return_value="request_methods") as mock_endpoint, \
+             patch.object(type(self.subject), 'service_address', return_value="http://request_methods:8000") as mock_service_address:
+            response_mock = Mock()
+            response_mock.json = Mock(return_value=self.attributes)
+            requests_request.return_value = response_mock
+            json_dumps.return_value = self.json_dumps_attributes
+
+            assert_equal(self.subject.request("create", params=self.attributes), self.attributes)
+            json_dumps.assert_called_once_with(self.attributes)
+            requests_request.assert_called_once_with('post', "http://request_methods:8000/request_methods/create",
+                                                     data=self.json_dumps_attributes, headers=self.headers)
+            response_mock.json.assert_called_with()
+            mock_endpoint.assert_called_once()
+            mock_service_address.assert_called_once()
+
+    @patch('json.dumps')
+    @patch('requests.request')
+    def test_request_with_id_parameter(self, requests_request, json_dumps):
+        with patch.object(type(self.subject), 'endpoint', return_value="request_methods") as mock_endpoint, \
+             patch.object(type(self.subject), 'service_address', return_value="http://request_methods:8000") as mock_service_address:
+            response_mock = Mock()
+            response_mock.json = Mock(return_value=self.attributes)
+            requests_request.return_value = response_mock
+
+            attributes = {'id': 42}
+            self.subject.request(":id/something", params=attributes)
+            json_dumps.assert_called_once_with({})
+            requests_request.assert_called_once_with('post', "http://request_methods:8000/request_methods/42/something",
+                                                     data=json.dumps({}), headers=self.headers)
+            response_mock.json.assert_called_with()
+            mock_endpoint.assert_called_once()
+
+


### PR DESCRIPTION
To better decouple the classes.

Closes https://github.com/mezuro/kalibro_client_py/issues/27