### PR TITLE
Handle HotspotMetrics on MetricConfiguration set

### DIFF
--- a/kalibro_client/configurations/metric_configuration.py
+++ b/kalibro_client/configurations/metric_configuration.py
@@ -1,7 +1,8 @@
 from kalibro_client.base import attributes_class_constructor,\
     entity_name_decorator
 from kalibro_client.configurations.base import Base
-from kalibro_client.miscellaneous import CompoundMetric, Metric, NativeMetric
+from kalibro_client.miscellaneous import CompoundMetric, Metric, NativeMetric,\
+    HotspotMetric
 
 
 @entity_name_decorator
@@ -62,6 +63,8 @@ class MetricConfiguration(attributes_class_constructor('MetricConfigurationAttr'
         if isinstance(value, dict):
             if value['type'] == "NativeMetricSnapshot":
                 self._metric = NativeMetric(**value)
+            elif value['type'] == "HotspotMetricSnapshot":
+                self._metric = HotspotMetric(**value)
             else:
                 self._metric = CompoundMetric(**value)
         elif isinstance(value, Metric):

--- a/tests/configurations/test_metric_configuration.py
+++ b/tests/configurations/test_metric_configuration.py
@@ -4,10 +4,11 @@ from mock import patch
 from nose.tools import assert_equal, assert_true, assert_in, raises
 
 from kalibro_client.configurations import MetricConfiguration
-from kalibro_client.miscellaneous import NativeMetric, CompoundMetric, Metric
+from kalibro_client.miscellaneous import NativeMetric, CompoundMetric, Metric,\
+    HotspotMetric
 
 from tests.factories import MetricConfigurationFactory, NativeMetricFactory, \
-    CompoundMetricFactory
+    CompoundMetricFactory, HotspotMetricFactory
 
 from tests.helpers import not_raises
 
@@ -40,6 +41,12 @@ class TestMetricConfiguration(TestCase):
         metric = NativeMetricFactory.build()
         self.subject.metric = metric._asdict()
         assert_true(isinstance(self.subject.metric, NativeMetric))
+        assert_equal(self.subject.metric, metric)
+
+    def test_metric_setter_with_hotspot_metric(self):
+        metric = HotspotMetricFactory.build()
+        self.subject.metric = metric._asdict()
+        assert_true(isinstance(self.subject.metric, HotspotMetric))
         assert_equal(self.subject.metric, metric)
 
     def test_metric_setter_with_compound_metric(self):


### PR DESCRIPTION
The metric setter now handles HotspotMetrics. Not handling was as bug.