### PR TITLE
Fix acceptance tests that depend on a processing state

### DIFF
--- a/features/repository/processing/last_processing_state.feature
+++ b/features/repository/processing/last_processing_state.feature
@@ -13,4 +13,4 @@ Feature: Last processing state
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the last_processing_state method for the given repository
-    Then I should get "PREPARING"
+    Then I should get a valid state

--- a/features/repository/processing/processing.feature
+++ b/features/repository/processing/processing.feature
@@ -13,7 +13,7 @@ Feature: Processing
     And I call the process method for the given repository
     And I wait up to 1 seconds
     When I call the processing method for the given repository
-    Then I should get a Processing with state "PREPARING"
+    Then I should get a Processing
 
   @kalibro_processor_restart @kalibro_configuration_restart
   Scenario: Processing with one repository just after with ready processing

--- a/features/steps/processing.py
+++ b/features/steps/processing.py
@@ -5,7 +5,7 @@ from kalibro_client.processor import Processing, ProcessTime
 
 @when(u'I call the processes_times method for the given processing')
 def step_impl(context):
-    context.process_times = context.processing.process_times()
+    context.process_times = context.response.process_times()
 
 @then(u'I should get a list of ProcessTimes')
 def step_impl(context):

--- a/features/steps/processing.py
+++ b/features/steps/processing.py
@@ -1,5 +1,5 @@
 from behave import *
-from nose.tools import assert_is_instance, assert_true, assert_equal
+from nose.tools import assert_is_instance, assert_true, assert_equal, assert_in
 
 from kalibro_client.processor import Processing, ProcessTime
 
@@ -19,4 +19,10 @@ def step_impl(context):
 
 @then(u'I should get a Processing with state "{}"')
 def step_impl(context, state):
-    assert_equal(context.processing.state, state)
+    assert_equal(context.response.state, state)
+
+@then(u'I should get a valid state')
+def step_impl(context):
+    states = ["PREPARING", "DOWNLOADING", "COLLECTING",
+            "CHECKING", "BUILDING", "AGGREGATING", "CALCULATING", "INTERPRETING"]
+    assert_in(context.response, states)

--- a/features/steps/repository.py
+++ b/features/steps/repository.py
@@ -41,7 +41,7 @@ def step_impl(context):
 
 @when(u'I call the processing method for the given repository')
 def step_impl(context):
-    context.processing = context.repository.processing()
+    context.response = context.repository.processing()
 
 @when(u'I ask for all the repositories')
 def step_impl(context):


### PR DESCRIPTION
That kind of tests are highly dependent on the machine running
the tests. That caused Travis to fail too frequently.
Now, instead of checking for a specific state, we check
if a state is valid or if we can retrieve a Processing.

Signed off by: Heitor Reis <marcheing@gmail.com>